### PR TITLE
keep aspect ratio in plotted graph test gamma

### DIFF
--- a/matlab/acc2021/testGamma.m
+++ b/matlab/acc2021/testGamma.m
@@ -91,5 +91,6 @@ xticks(-5:1);
 yticks(-5:1);
 xlim([-5,0.2]);
 ylim([-5,0.2]);
+axis square
 print(gcf,'figures/benchmark-gamma.eps', '-depsc');
 print(gcf,'figures/benchmark-gamma.png', '-dpng', '-r800');


### PR DESCRIPTION
This small PR makes sure the plotted graphs don't get distorted when enlarging the window